### PR TITLE
[FIX] FIX t-foeach key in qweb...

### DIFF
--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -31,7 +31,7 @@
         "web.assets_backend": [
             "mail_tracking/static/src/css/mail_tracking.scss",
             "mail_tracking/static/src/js/failed_message/mail_failed_box.esm.js",
-            "mail_tracking/static/src/js/failed_message/discuss.esm.js",
+            #"mail_tracking/static/src/js/failed_message/discuss.esm.js",
             "mail_tracking/static/src/xml/mail_tracking.xml",
             "mail_tracking/static/src/xml/failed_message/common.xml",
             "mail_tracking/static/src/xml/failed_message/thread.xml",

--- a/mail_tracking/models/ir_mail_server.py
+++ b/mail_tracking/models/ir_mail_server.py
@@ -91,18 +91,10 @@ class IrMailServer(models.Model):
         return smtp_server_used
 
     @api.model
-    def send_email(
-        self,
-        message,
-        mail_server_id=None,
-        smtp_server=None,
-        smtp_port=None,
-        smtp_user=None,
-        smtp_password=None,
-        smtp_encryption=None,
-        smtp_debug=False,
-        smtp_session=None,
-    ):
+    def send_email(self, message, mail_server_id=None, smtp_server=None, smtp_port=None,
+                   smtp_user=None, smtp_password=None, smtp_encryption=None,
+                   smtp_ssl_certificate=None, smtp_ssl_private_key=None,
+                   smtp_debug=False, smtp_session=None):
         message_id = False
         tracking_email = self._tracking_email_get(message)
         smtp_server_used = self.sudo()._smtp_server_get(mail_server_id, smtp_server)
@@ -115,6 +107,8 @@ class IrMailServer(models.Model):
                 smtp_user=smtp_user,
                 smtp_password=smtp_password,
                 smtp_encryption=smtp_encryption,
+                smtp_ssl_certificate=smtp_ssl_certificate,
+                smtp_ssl_private_key=smtp_ssl_certificate,
                 smtp_debug=smtp_debug,
                 smtp_session=smtp_session,
             )

--- a/mail_tracking/static/src/js/models/mail_tracking.esm.js
+++ b/mail_tracking/static/src/js/models/mail_tracking.esm.js
@@ -8,7 +8,7 @@ registerPatch({
     modelMethods: {
         convertData(data) {
             const data2 = this._super(data);
-            if ("partner_trackings" in data) {
+            if ("partner_trackings" in data && data.partner_trackings.tracking_id) {
                 data2.partner_trackings = data.partner_trackings;
             }
             return data2;

--- a/mail_tracking/static/src/xml/mail_tracking.xml
+++ b/mail_tracking/static/src/xml/mail_tracking.xml
@@ -71,7 +71,7 @@
                         t-as="tracking"
                         t-key="tracking.tracking_id"
                     >
-                    >
+
                     <t t-if="!tracking_first">
                           -
                     </t>


### PR DESCRIPTION
 ... (owl always require unique t-key in t-foreach)
 
 FIX the PR sent to OCA. Add a validation of t-key exists in the foreach of the activities and disable discuss.esm.js because it uses requirements that do not exist anymore. 
If you can't mix it in the PR I can start a new one in OCA continuing the excellent work you did. 